### PR TITLE
make 2 remaining days for adding entries

### DIFF
--- a/src/lib/components/EntryForm.svelte
+++ b/src/lib/components/EntryForm.svelte
@@ -20,6 +20,15 @@
 	} from '@internationalized/date';
 	import { Calendar } from './ui/calendar';
 
+	/**
+	 * Calculate the max date for entry submission (challenge end + 2 days grace period)
+	 */
+	function getMaxDateForEntry(endsAt: Date): DateValue {
+		const maxDate = new Date(endsAt);
+		maxDate.setUTCDate(maxDate.getUTCDate() + 2);
+		return parseDate(maxDate.toISOString().split('T')[0]);
+	}
+
 	interface Props {
 		formData: SuperValidated<Infer<typeof newEntry>>;
 		disciplines: (typeof disciplineTable.$inferSelect)[];
@@ -159,7 +168,7 @@
 										value={value as DateValue}
 										bind:placeholder
 										minValue={parseDate(challenge.startsAt.toISOString().split('T')[0])}
-										maxValue={today(getLocalTimeZone())}
+										maxValue={getMaxDateForEntry(challenge.endsAt)}
 										calendarLabel="Tag des Eintrags"
 										onValueChange={(v) => {
 											if (v) {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,10 +3,17 @@
 	import Leaderboard from '$lib/components/Leaderboard.svelte';
 
 	import Button from '$lib/components/ui/button/button.svelte';
+	import * as Card from '$lib/components/ui/card';
 
 	import { SquareArrowOutUpRight } from '@lucide/svelte';
+	import { canAddEntries, prettyDate } from '$lib/utils';
 
 	let { data } = $props();
+
+	// Filter challenges that still accept entries
+	const openForEntriesChallenges = $derived(
+		data.openForEntriesChallenges.filter((c) => canAddEntries(c))
+	);
 </script>
 
 {#if data.user}
@@ -58,6 +65,35 @@
 				</p>
 			</div>
 		{/each}
+
+		<!-- Section for challenges still open for entries -->
+		{#if openForEntriesChallenges.length > 0}
+			<div>
+				<h2 class="mb-4 text-2xl font-bold">Offen für Einträge</h2>
+				<div class="grid gap-4 md:grid-cols-3">
+					{#each openForEntriesChallenges as openChallenge}
+						<a href="/clubs/{openChallenge.clubId}/challenge/{openChallenge.id}">
+							<Card.Root>
+								<Card.Header>
+									<Card.Title>{openChallenge.name}</Card.Title>
+									<Card.Description
+										>{prettyDate(new Date(openChallenge.startsAt))} - {prettyDate(
+											new Date(openChallenge.endsAt)
+										)}</Card.Description
+									>
+								</Card.Header>
+								<Card.Footer>
+									<p class="mt-4 text-red-500">
+										{openChallenge.daysRemaining}
+										{openChallenge.daysRemaining === 1 ? 'Tag' : 'Tage'} noch
+									</p>
+								</Card.Footer>
+							</Card.Root>
+						</a>
+					{/each}
+				</div>
+			</div>
+		{/if}
 	</div>
 {:else}
 	<section>

--- a/src/routes/clubs/[clubId]/challenge/[challengeId]/+page.server.ts
+++ b/src/routes/clubs/[clubId]/challenge/[challengeId]/+page.server.ts
@@ -65,12 +65,14 @@ export const actions: Actions = {
 		const challengeStart = new Date(qChallenge.startsAt);
 		challengeStart.setUTCHours(0, 0, 0, 0);
 		const challengeEnd = new Date(qChallenge.endsAt);
+		// Add 2-day grace period for entries
+		challengeEnd.setUTCDate(challengeEnd.getUTCDate() + 2);
 		challengeEnd.setUTCHours(23, 59, 59, 999);
 
 		if (entryDate < challengeStart || entryDate > challengeEnd) {
 			return error(
 				400,
-				`Einträge können nur zwischen ${prettyDate(qChallenge.startsAt)} und ${prettyDate(qChallenge.endsAt)} erstellt werden`
+				`Einträge können nur zwischen ${prettyDate(qChallenge.startsAt)} und ${prettyDate(new Date(qChallenge.endsAt.getTime() + 2 * 24 * 60 * 60 * 1000))} erstellt werden`
 			);
 		}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a 2-day grace period after challenge end dates so entries can be submitted up to 2 days past the deadline.
  * New "Offen für Einträge" / "Open for Entries" section lists challenges accepting late submissions and shows days remaining.

* **Bug Fixes**
  * Date picker and server-side validation updated so entry dates are constrained to challenge range (including the 2-day grace) with clearer error messaging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->